### PR TITLE
Refactor docker bundler & test server

### DIFF
--- a/.env
+++ b/.env
@@ -105,10 +105,12 @@ SITE_OWNER=Site Owner
 # Demo mode. Set =1 to enable.
 IS_DEMO_MODE=0
 
-# AWS credentials
-AWS_ACCESS_KEY=
-AWS_SECRET_ACCESS_KEY=
+# AWS credentials.
+# AWS User: auth-web-demo_read
 AWS_REGION=us-west-2
+AWS_ACCESS_KEY=AKIAJL2H6XPJPUEGZMMA
+# AWS_SECRET_ACCESS_KEY=
+# Set secret in host environment
 
 # S3 content params
 CONTENT_S3_INDEX_PAGE_BUCKET=auth-web-demo-private

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.3
+  - 2.3.3
 
 services:
   - docker
@@ -18,7 +18,6 @@ before_install:
   - docker -v
   - docker-compose -v
   - sudo apt-get update
-  - sudo apt-get install docker-engine=17.03.0-ce~trusty
   - docker -v
   - docker-compose -v
 
@@ -33,16 +32,19 @@ install:
   - docker-compose build
 
 before_script:
+  - docker-compose run --rm web rails db:setup
+  # Use 'run --rm ...` instead of 'exec ...` so that entrypoint's customized bundle install runs completely.
   - docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d
+  # The detached `up` also runs entrypoint — but because it's detached,
+  # bundle install doesn't finish before shell moves on to next commands.
   - docker ps
-  - docker-compose exec web rails db:setup
 
 script:
-  - docker-compose exec web rails test
+  - docker-compose run --rm web rails test
 
 before_cache:
   - docker-compose logs > ./log/docker-ci.log
-  - docker-compose exec web rails tmp:clear
+  - docker-compose run --rm web rails tmp:clear
   - docker-compose down
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,14 @@ install:
 before_script:
   - docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d
   - docker ps
-  - docker-compose exec web bin/rails r bin/setup
+  - docker-compose exec web rails db:setup
 
 script:
-  - docker-compose exec web bin/rails test
+  - docker-compose exec web rails test
 
 before_cache:
   - docker-compose logs > ./log/docker-ci.log
-  - docker-compose exec web bin/rails tmp:clear
+  - docker-compose exec web rails tmp:clear
   - docker-compose down
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ before_script:
   # The detached `up` also runs entrypoint — but because it's detached,
   # bundle install doesn't finish before shell moves on to next commands.
   - docker ps
-  - printenv | grep 'TEST_KEY'
-  - docker-compose run --rm --no-deps web printenv | grep 'TEST_KEY'
   - docker-compose exec web rails db:setup
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,14 +39,14 @@ before_script:
   # The detached `up` also runs entrypoint — but because it's detached,
   # bundle install doesn't finish before shell moves on to next commands.
   - docker ps
-  - docker-compose run --rm web rails db:setup
+  - docker-compose exec web rails db:setup
 
 script:
-  - docker-compose run --rm web rails test
+  - docker-compose exec web rails test
 
 before_cache:
   - docker-compose logs > ./log/docker-ci.log
-  - docker-compose run --rm web rails tmp:clear
+  - docker-compose exec web rails tmp:clear
   - docker-compose down
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - docker -v
   - docker-compose -v
 
-  # Once travis supports same version, the following can be removed
+  # Once travis supports same version of docker compose, the following can be removed
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
@@ -33,12 +33,13 @@ install:
   - docker-compose build
 
 before_script:
-  - docker-compose run --rm --no-deps web rails db:setup
-  # Use 'run --rm ...` instead of 'exec ...` so that entrypoint's customized bundle install runs completely.
+  - docker-compose run --rm --no-deps web echo 'Gems now pre-installed.'
+  # Use 'run ...` instead of 'exec ...` so that entrypoint's customized bundle install runs completely.
   - docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d
   # The detached `up` also runs entrypoint — but because it's detached,
   # bundle install doesn't finish before shell moves on to next commands.
   - docker ps
+  - docker-compose run --rm web rails db:setup
 
 script:
   - docker-compose run --rm web rails test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
   - docker -v
   - docker-compose -v
   - sudo apt-get update
+  - sudo apt-get install docker-engine
   - docker -v
   - docker-compose -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - docker-compose build
 
 before_script:
+  - docker-compose run --rm --no-deps web printenv | grep 'AWS_ACCESS_KEY'
   - docker-compose run --rm --no-deps web echo 'Gems now pre-installed.'
   # Use 'run ...` instead of 'exec ...` so that entrypoint's customized bundle install runs completely.
   - docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - docker -v
   - docker-compose -v
   - sudo apt-get update
-  - sudo apt-get install docker-engine
+  - sudo apt-get install docker-engine=17.03.0-ce~trusty
   - docker -v
   - docker-compose -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - docker-compose build
 
 before_script:
-  - docker-compose run --rm web rails db:setup
+  - docker-compose run --rm --no-deps web rails db:setup
   # Use 'run --rm ...` instead of 'exec ...` so that entrypoint's customized bundle install runs completely.
   - docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d
   # The detached `up` also runs entrypoint — but because it's detached,

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,14 @@ install:
 before_script:
   - docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d
   - docker ps
-  - docker-compose exec test rails r bin/setup
+  - docker-compose exec web bin/rails r bin/setup
 
 script:
-  - docker-compose exec test rails test
+  - docker-compose exec web bin/rails test
 
 before_cache:
   - docker-compose logs > ./log/docker-ci.log
-  - docker-compose exec test rails tmp:clear
+  - docker-compose exec web bin/rails tmp:clear
   - docker-compose down
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ before_script:
   # The detached `up` also runs entrypoint — but because it's detached,
   # bundle install doesn't finish before shell moves on to next commands.
   - docker ps
-  - printenv | grep 'AWS_ACCESS_KEY'
-  - docker-compose run --rm --no-deps web printenv | grep 'AWS_ACCESS_KEY'
+  - printenv | grep 'TEST_KEY'
+  - docker-compose run --rm --no-deps web printenv | grep 'TEST_KEY'
   - docker-compose exec web rails db:setup
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_script:
   # The detached `up` also runs entrypoint — but because it's detached,
   # bundle install doesn't finish before shell moves on to next commands.
   - docker ps
+  - printenv | grep 'AWS_ACCESS_KEY'
   - docker-compose run --rm --no-deps web printenv | grep 'AWS_ACCESS_KEY'
   - docker-compose exec web rails db:setup
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,13 @@ install:
   - docker-compose build
 
 before_script:
-  - docker-compose run --rm --no-deps web printenv | grep 'AWS_ACCESS_KEY'
   - docker-compose run --rm --no-deps web echo 'Gems now pre-installed.'
   # Use 'run ...` instead of 'exec ...` so that entrypoint's customized bundle install runs completely.
   - docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d
   # The detached `up` also runs entrypoint — but because it's detached,
   # bundle install doesn't finish before shell moves on to next commands.
   - docker ps
+  - docker-compose run --rm --no-deps web printenv | grep 'AWS_ACCESS_KEY'
   - docker-compose exec web rails db:setup
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,5 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 # https://unboxed.co/blog/docker-re-bundling/
 
 ENV PATH="/bundle/bin:${PATH}"
+RUN echo "$PATH"
 # Bundle installs with binstubs to our custom /bundle/bin volume path. Let system use those stubs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 # Add bundle entry point to handle bundle cache
 # https://unboxed.co/blog/docker-re-bundling/
 
-ENV PATH="/bundle/bin:${PATH}"
-RUN echo "$PATH"
+ENV BUNDLE_PATH=/bundle/path \
+    BUNDLE_BIN=/bundle/bin
+ENV PATH="${BUNDLE_BIN}:${PATH}"
 # Bundle installs with binstubs to our custom /bundle/bin volume path. Let system use those stubs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,3 +65,6 @@ RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 # Add bundle entry point to handle bundle cache
 # https://unboxed.co/blog/docker-re-bundling/
+
+ENV PATH="/bundle/bin:${PATH}"
+# Bundle installs with binstubs to our custom /bundle/bin volume path. Let system use those stubs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,27 +51,6 @@ WORKDIR $INSTALL_PATH
 # By doing this, Docker will be smart enough to execute all
 # future commands from within this directory.
 
-COPY Gemfile* ./
-# This is going to copy in the Gemfile and Gemfile.lock from our
-# work station at a path relative to the Dockerfile to the
-# jfmk_auth/ path inside of the Docker image.
-#
-# It copies it to /jfmk_auth because of the WORKDIR being set.
-#
-# We copy in our Gemfile before the main app because Docker is
-# smart enough to cache "layers" when you build a Docker image.
-#
-# You see, each command we have in the Dockerfile is going to be
-# ran and then saved as a separate layer. Docker is smart enough
-# to only re-build pieces that change, in order from top to bottom.
-#
-# This is an advanced concept but it means that we'll be able to
-# cache all of our gems so that if we make an application code
-# change, it won't re-run bundle install unless a gem changed.
-
-RUN bundle install --jobs 5
-# Install all gems. Paralleize the jobs for faster install.
-
 COPY . .
 # This might look a bit alien but it's copying in everything from
 # the current directory relative to the Dockerfile, over to the
@@ -81,22 +60,8 @@ COPY . .
 # this is how the unix command cp (copy) works. It stands for the
 # current directory.
 
-#RUN bundle exec rake RAILS_ENV=production DATABASE_URL=postgresql://user:pass@127.0.0.1/dbname ACTION_CABLE_ALLOWED_REQUEST_ORIGINS=foo,bar SECRET_TOKEN=dummytoken assets:precompile
-# Provide a dummy DATABASE_URL and more to Rails so it can pre-compile
-# assets. The values do not need to be real, just valid syntax.
-#
-# If you're saving your assets to a CDN and are working with multiple
-# app instances, you may want to remove this step and deal with asset
-# compilation at a different stage of your deployment.
-
-#VOLUME ["$INSTALL_PATH/public"]
-# In production you will very likely reverse proxy Rails with nginx.
-# This sets up a volume so that nginx can read in the assets from
-# the Rails Docker image without having to copy them to the Docker host.
-
-CMD puma -C config/puma.rb
-# This is the command that's going to be ran by default if you run the
-# Docker image without any arguments.
-#
-# In our case, it will start the Puma app server while passing in
-# its config file.
+COPY ./docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+# Add bundle entry point to handle bundle cache
+# https://unboxed.co/blog/docker-re-bundling/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Note:
 
 `docker-compose up` Build the docker images, install dependencies, and start the services. 
 
-Once the docker services are build and running, the web service will occupy the current terminal with the running puma server log. Open a new terminal instance to issue any additional commands, or run the prior command in detached mode `docker-compose up -d` to free the current terminal session (more on that below). 
+Once the docker services are build and running, the web service will occupy the current terminal with the running puma server log. Open a new terminal instance to issue any additional commands. 
 
 `docker-compose exec web bin/setup` Set up the database.
 
@@ -69,7 +69,7 @@ The `web` service uses the `Dockerfile` to build itself. It defines an `ENTRYPOI
 `docker-compose exec web bin/update` Install a new gem, or to run a database migration.
 
 `docker-compose down; docker-compose up -d; docker attach jfmkauth_web_1`
-A common call chain to stop any existing/hung containers, stand up all services in detached mode, connect to view web service only (to view running log and interact with byebug).
+A common call chain during development to stop any existing/hung containers, stand up all services in detached mode, connect to view web service only (to view running log and interact with byebug). Be aware 'exec' bypasses the entrypoint script which ensures gems are up to date (use `docker-compose run --rm ...` instead of `docker-compose exec ...` if that is a concern - had to do this for the CI override file).
 
 `docker-compose build` If there are changes to the `Dockerfile` or the `docker-compose` files, the containers may need to be rebuilt.
 
@@ -127,11 +127,7 @@ Certificate is good for 90 days. To renew, run or schedule a variation of `herok
 - __Devise.__ In future projects I will use [Devise](https://github.com/plataformatec/devise) for authentication. Just wanted to write my own first to better understand the auth & user management process. 
 
 # TODO
-- entrypoint multi commands?
-- v3 volume
 - do we need to precompile or does heroko do that?
-- can we just call rails server? puma config?
-
 
 # License
 Copyright © JFMK, LLC Released under the [MIT License](https://github.com/jfroom/jfmk-auth/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Note:
 
 `docker-compose up` Build the docker images.
 
-`docker-compose exec web rails r bin/setup` Set up rails and the database.
+`docker-compose exec web bin/setup` Set up rails and the database.
 
-`docker-compose exec web rails db:seed` Seed the database with two users: `admin:Admin123` and `user:User123`. Use the admin login to change those immediately.
+`docker-compose exec web bin/rails db:seed` Seed the database with two users: `admin:Admin123` and `user:User123`. Use the admin login to change those immediately.
 
 ## Development 
 
@@ -62,10 +62,11 @@ Note:
 `docker-compose down; docker-compose up -d; docker attach jfmkauth_web_1`
 A common call chain to stop any existing/hung containers, stand up all services in detached mode, connect to view web service only (to view running log and interact with byebug).
 
-`docker-compose exec web rails r bin/update` Performs Rails db migration, checks for bundle changes. This will install any new gems in the container but not the image - see next command.  
+`docker-compose exec web bin/update` Performs Rails db migration, checks for bundle changes. This will install any new gems in the container but not the image - see next command.  
 
 `docker-compose build` If Gemfile or Gemfile.lock have changed, docker web image needs to be rebuilt. (TODO: make this [more dynamic](http://bradgessler.com/articles/docker-bundler/))
 
+These [docker shortcuts](https://www.digitalocean.com/community/tutorials/how-to-remove-docker-images-containers-and-volumes) to clean up old docker images/containers/volumes is very handy.
 
 ## Database
 
@@ -75,17 +76,17 @@ A common call chain to stop any existing/hung containers, stand up all services 
 
 ## Test
 
-`docker-compose exec test rails test` Run tests (also importantly sets Rails.env = 'test').
+`docker-compose exec web bin/rails test` Run tests (also importantly sets Rails.env = 'test').
 
-`vnc://localhost:5900  password:secret` To interactive with and debug Selenium sessions, use VNC to connect to the Selenium service. [VNC Viewer](https://www.realvnc.com/download/viewer/) works well, and on OS X Screen Sharing app is built-in.
+`vnc://localhost:5900 password:secret` To interactive with and debug Selenium sessions, use VNC to connect to the Selenium service. [VNC Viewer](https://www.realvnc.com/download/viewer/) works well, and on OS X Screen Sharing app is built-in.
 
-To visit the test app on local machine: `open http://localhost:3001/`. To visit in the VNC session visit: `http://test:3001`. 
+To visit the test app on local machine: `open http://localhost:3001/`. To visit in the VNC session visit: `http://web:3001`. 
 
 Commits to master are automatically tested by [Travis CI](https://travis-ci.org/jfroom/jfmk-auth). 
 
 Tests use: 
 - [`railsware/rack_session_access`](//github.com/railsware/rack_session_access) with Capybara to conveniently bypass session authenticating which speeds tests up.
-- [`thoughtbot/climate_control`](//github.com/thoughtbot/climate_control) to adjust ENV vars for models/integration, and a custom `/test/backdoor/` route for the capybara test enviornemnt only to adjust ENV.
+- [`thoughtbot/climate_control`](//github.com/thoughtbot/climate_control) to adjust ENV vars for models/integration, and a custom `/test/backdoor/` route for the capybara test environment only to adjust ENV.
 
 
 ## Deploy

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '3.1'
 
 services:
   postgres:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,20 +1,11 @@
-version: '3.1'
+version: '2.1'
 
 services:
   postgres:
-    expose:
-      - 5432 # Not exposing port externally because it conflicts a port used by Travis
+    expose: [5432] # Not exposing port externally because it conflicts a port used by Travis
 
   web:
-    expose:
-      - 3000
-
-  test:
-    environment:
-      - AWS_ACCESS_KEY
-      - AWS_SECRET_ACCESS_KEY
-    expose:
-      - 3001
+    expose: [3000, 3001]
 
   selenium:
     expose: [4444, 5900]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '3.1'
 
 services:
   postgres:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,17 +1,11 @@
-version: '3.1'
+version: '2.1'
 
 services:
   postgres:
-    ports:
-      - '5432:5432'
+    ports: ['5432:5432']
 
   web:
-    ports:
-      - '3000:3000'
-
-  test:
-    ports:
-      - '3001:3001'
+    ports: ['3000:3000', '3001:3001']
 
   selenium:
     ports: ['4444:4444', '5900:5900']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,18 @@
-version: '2.1'
+version: '3.1'
 
 services:
-  # https://unboxed.co/blog/docker-re-bundling/
-  bundle_cache:
-    command: "echo 'bundle_cache service is going to start and then immediately exit since it is just a volume.'"
-    image: alpine:latest
-    volumes:
-      - 'bundle_cache:/bundle'
-
   web:
     depends_on:
-      - bundle_cache
       - postgres
     build: .
     env_file: .env
     command: >
       bash -c "
-        # Run test server detached without tail log
-        RAILS_ENV=test bundle exec puma -b tcp://0.0.0.0:3001 -d &&
-        # Run web server and tail the log
-        bundle exec puma -C config/puma.rb
+        # Run test server detached
+        RAILS_ENV=test puma -b tcp://0.0.0.0:3001 -d &&
+
+        # Run web server
+        puma -C config/puma.rb
         "
     environment:
       - BUNDLE_PATH=/bundle
@@ -28,28 +21,28 @@ services:
       - TEST_APP_HOST=web
       - TEST_PORT=3001
     volumes:
-      - '.:/jfmk_auth'
-    volumes_from:
-      - bundle_cache
-    # Allow interaction on detached sessions like byebug
+      - .:/jfmk_auth
+      - bundle_cache:/bundle
+      # Cache bundle files into a volume. https://unboxed.co/blog/docker-re-bundling/
     stdin_open: true
     tty: true
+    # Allow interaction on detached sessions like byebug
 
   postgres:
-    image: 'postgres:9.6.1'
+    image: postgres:9.6.1
     environment:
-      POSTGRES_USER: 'jfmk_auth'
-      POSTGRES_PASSWORD: 'yourpassword'
+      POSTGRES_USER: jfmk_auth
+      POSTGRES_PASSWORD: yourpassword
     volumes:
-      - 'postgres:/var/lib/postgresql/data'
+      - postgres:/var/lib/postgresql/data
     logging:
-      driver: 'none'
+      driver: none
 
   selenium:
     #image: selenium/standalone-firefox-debug:2.48.2
     image: selenium/standalone-chrome-debug:3.0.1-germanium # :2.27 not working
     logging:
-      driver: 'none'
+      driver: none
 
 volumes:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
         puma -C config/puma.rb
         "
     environment:
-      - BUNDLE_PATH=/bundle
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
       - TEST_APP_HOST=web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,40 @@
-version: '3.1'
+version: '2.1'
 
 services:
+  # https://unboxed.co/blog/docker-re-bundling/
+  bundle_cache:
+    command: "echo 'bundle_cache service is going to start and then immediately exit since it is just a volume.'"
+    image: alpine:latest
+    volumes:
+      - 'bundle_cache:/bundle'
+
+  web:
+    depends_on:
+      - bundle_cache
+      - postgres
+    build: .
+    env_file: .env
+    command: >
+      bash -c "
+        # Run test server detached without tail log
+        RAILS_ENV=test bundle exec puma -b tcp://0.0.0.0:3001 -d &&
+        # Run web server and tail the log
+        bundle exec puma -C config/puma.rb
+        "
+    environment:
+      - BUNDLE_PATH=/bundle
+      - SELENIUM_HOST=selenium
+      - SELENIUM_PORT=4444
+      - TEST_APP_HOST=web
+      - TEST_PORT=3001
+    volumes:
+      - '.:/jfmk_auth'
+    volumes_from:
+      - bundle_cache
+    # Allow interaction on detached sessions like byebug
+    stdin_open: true
+    tty: true
+
   postgres:
     image: 'postgres:9.6.1'
     environment:
@@ -11,37 +45,6 @@ services:
     logging:
       driver: 'none'
 
-  web:
-    depends_on:
-      - postgres
-    build: .
-    env_file: .env
-    volumes:
-      - '.:/jfmk_auth'
-
-    # Allow interaction on detached sessions like byebug
-    stdin_open: true
-    tty: true
-
-  test:
-    build: .
-    env_file: .env
-    environment:
-      - RAILS_ENV=test
-      - TEST_APP_HOST=test
-      - PORT=3001
-      - SELENIUM_HOST=selenium
-      - SELENIUM_PORT=4444
-    volumes:
-      - '.:/jfmk_auth'
-    depends_on:
-      - postgres
-      - selenium
-
-    # Allow interaction on detached sessions like byebug
-    stdin_open: true
-    tty: true
-
   selenium:
     #image: selenium/standalone-firefox-debug:2.48.2
     image: selenium/standalone-chrome-debug:3.0.1-germanium # :2.27 not working
@@ -50,3 +53,4 @@ services:
 
 volumes:
   postgres:
+  bundle_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     depends_on:
       - postgres
     build: .
-    env_file: .env
+
     command: >
       bash -c "
         # Run test server detached
@@ -14,7 +14,11 @@ services:
         # Run web server
         puma -C config/puma.rb
         "
+    env_file: .env
     environment:
+      - TEST_KEY
+      - AWS_SECRET_ACCESS_KEY
+      - APP_NAME
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
       - TEST_APP_HOST=web

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Ensure all gems installed. Add binstubs to bin which has been added to PATH in Dockerfile.
-bundle check || bundle install --binstubs=/bundle/bin
+bundle check || bundle install --binstubs="$BUNDLE_BIN"
 
 # Finally call command issued to the docker service
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Exit on fail
 set -e
-bundle check || bundle install
+
+# Ensure all gems installed. Add binstubs to bin which has been added to PATH in Dockerfile.
+bundle check || bundle install --binstubs=/bundle/bin
+
+# Finally call command issued to the docker service
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+bundle check || bundle install
+exec "$@"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,10 +39,10 @@ end
 
 # CAPYBARA
 # Use container's shell to find the docker ip address
-Capybara.app_host = "http://#{ENV['TEST_APP_HOST']}:#{ENV['PORT']}"
+Capybara.app_host = "http://#{ENV['TEST_APP_HOST']}:#{ENV['TEST_PORT']}"
 Capybara.javascript_driver = :selenium # TODO: add :webkit option for faster tests
 Capybara.run_server = false
-Capybara.server_port = ENV['PORT']
+Capybara.server_port = ENV['TEST_PORT']
 
 args = ['--no-default-browser-check', '--start-maximized', '--disable-web-security', '--allow-hidden-media-playback']
 caps = Selenium::WebDriver::Remote::Capabilities.chrome("chromeOptions" => {"args" => args})

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,7 +42,6 @@ end
 Capybara.app_host = "http://#{ENV['TEST_APP_HOST']}:#{ENV['TEST_PORT']}"
 Capybara.javascript_driver = :selenium # TODO: add :webkit option for faster tests
 Capybara.run_server = false
-Capybara.server_port = ENV['TEST_PORT']
 
 args = ['--no-default-browser-check', '--start-maximized', '--disable-web-security', '--allow-hidden-media-playback']
 caps = Selenium::WebDriver::Remote::Capabilities.chrome("chromeOptions" => {"args" => args})


### PR DESCRIPTION
Docker/Bundler update:
- Refactor to try and speed up bundler installs. 
- Updated dockerfile & docker-compose to have entrypoint that checks for bundler updates. This allows for more passive updating of gems, and doesn't require updating entire image layer for bundle like it was set up before (which required a compose rebuild and downloaded all gems again just to add a new gem).
- `bundle_cache` volume should persist across container builds

Test refactor:
- Removed `test` service
- Now `web` service has multiline command to start two puma servers:
  - 0.0.0.0:3000 with RAILS_ENV=development
  - 0.0.0.0:3001 with RAILS_ENV=test

Refactor based on these insights:
- https://unboxed.co/blog/docker-re-bundling/
- https://github.com/charlieegan3/docker-bundler-caching/