### PR TITLE
Add User.allow_auto_login feature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,7 +28,9 @@ Metrics/ClassLength:
 
 Metrics/MethodLength:
   Enabled: false
-
+Metrics/ParameterLists:
+  Enabled: false
+  
 Metrics/PerceivedComplexity:
   Enabled: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # https://github.com/nickjj/orats
 
-FROM ruby:2.3-slim
+FROM ruby:2.3.4-slim
 # Docker images can start off with nothing, but it's extremely
 # common to pull in from a base image. In our case we're pulling
 # in from the slim version of the official Ruby 2.3 image.

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.3'
+ruby '2.3.4'
 
 # Looking to use the Edge version? gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.1'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Rails personal project with user management & authentication to proxy serve a pr
 - Docker Compose for development & test; Travis for CI/CD; [Heroku Pipelines](https://devcenter.heroku.com/articles/pipelines) for production
 - 'Simple' [`has_secure_password`](http://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html) Rails API for authentication & cookie sessions. User is locked out after X failed attempts.
 - Authenticated users are served single-page app with a proxied index page, and expiring pre-signed URLs for sensitive S3 hosted content are parsed/injected. Demo content is instance of [`jfroom/portfolio-web`](//github.com/jfroom/portfolio-web).
+- 'Auto-login' feature can be enabled for a user, which creates a simple and aesthetic url: https://example.com/username. Be aware that using this lowers security threshold. Can implement [`has_secure_token`](http://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html) in future if this becomes a concern.
 - Tests with MiniTest for models & integration, and Capybara Selenium acceptance tests running in a docker service with Chrome standalone.
 - VNC locally into the Selenium session to interact and debug.
 - Let's Encrypt SSL certificates auto bound to the custom Heroku domain with [`letsencrypt-rails-heroku`](https://github.com/pixielabs/letsencrypt-rails-heroku).

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -72,6 +72,6 @@ class Admin::UsersController < ApplicationController
   private
 
   def user_params
-    params[:user].permit(:username, :password, :name, :login_locked)
+    params[:user].permit(:username, :password, :name, :login_locked, :allow_auto_login)
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,17 +1,11 @@
 class SessionsController < ApplicationController
-  before_action :check_logged_in, only: [:index, :login]
+  before_action :check_logged_in, only: [:index, :login, :auto_login]
   skip_before_action :login_required
 
   def login
     user = User.authenticate!(params[:username], params[:password])
     if user.present?
-      reset_session
-      session[:user_id] = user.id
-
-      # Email notify admin of a user login
-      unless user.admin? || ENV['IS_DEMO_MODE'] == '1'
-        notify_login(user.username)
-      end
+      process_login user
 
       # Admin goes to admin page, all other users go to root content page
       redirect_to user.admin? ? admin_root_path : root_path
@@ -33,6 +27,16 @@ class SessionsController < ApplicationController
     redirect_to root_path
   end
 
+  def auto_login
+    user = User.find_by_username params[:username]
+    if user.present? && user.allow_auto_login
+      process_login user, true
+    else
+      flash[:alert] = "Invalid username."
+    end
+    redirect_to root_path
+  end
+
   private
 
   # Trying to access login page when already logged in? Redirect to home page
@@ -44,9 +48,20 @@ class SessionsController < ApplicationController
     true
   end
 
-  def notify_login(username)
-    AdminMailer.activity_email(username, Time.zone.now.to_s,
-                               request.host, request.url, request.remote_ip, request.user_agent).deliver_later
+  def process_login(user, is_auto_login = false)
+    reset_session
+    session[:user_id] = user.id
+
+    # Email notify admin of a user login
+    unless user.admin? || ENV['IS_DEMO_MODE'] == '1'
+      notify_login(user.username, is_auto_login)
+    end
+  end
+
+  def notify_login(username, is_auto_login)
+    AdminMailer.activity_email(username, is_auto_login, Time.zone.now.to_s,
+                               request.host, request.url, request.remote_ip, request.user_agent
+                               ).deliver_later
   # Log any errors silently so user can still login
   rescue Net::SMTPAuthenticationError, Net::SMTPServerBusy, Net::SMTPSyntaxError, Net::SMTPFatalError,
          Net::SMTPUnknownError => e

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  before_action :check_logged_in, only: [:index, :login, :auto_login]
+  before_action :check_logged_in, only: %i(:index, :login, :auto_login)
   skip_before_action :login_required
 
   def login
@@ -53,15 +53,14 @@ class SessionsController < ApplicationController
     session[:user_id] = user.id
 
     # Email notify admin of a user login
-    unless user.admin? || ENV['IS_DEMO_MODE'] == '1'
-      notify_login(user.username, is_auto_login)
-    end
+    return if user.admin? || ENV['IS_DEMO_MODE'] == '1'
+    notify_login user.username, is_auto_login
   end
 
   def notify_login(username, is_auto_login)
     AdminMailer.activity_email(username, is_auto_login, Time.zone.now.to_s,
                                request.host, request.url, request.remote_ip, request.user_agent
-                               ).deliver_later
+                              ).deliver_later
   # Log any errors silently so user can still login
   rescue Net::SMTPAuthenticationError, Net::SMTPServerBusy, Net::SMTPSyntaxError, Net::SMTPFatalError,
          Net::SMTPUnknownError => e

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  before_action :check_logged_in, only: %i(:index, :login, :auto_login)
+  before_action :check_logged_in, only: %i[index login auto_login]
   skip_before_action :login_required
 
   def login
@@ -59,8 +59,7 @@ class SessionsController < ApplicationController
 
   def notify_login(username, is_auto_login)
     AdminMailer.activity_email(username, is_auto_login, Time.zone.now.to_s,
-                               request.host, request.url, request.remote_ip, request.user_agent
-                              ).deliver_later
+                               request.host, request.url, request.remote_ip, request.user_agent).deliver_later
   # Log any errors silently so user can still login
   rescue Net::SMTPAuthenticationError, Net::SMTPServerBusy, Net::SMTPSyntaxError, Net::SMTPFatalError,
          Net::SMTPUnknownError => e

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,5 +1,5 @@
 module Admin::UsersHelper
   def user_attributes
-    %w(username name admin login_locked login_attempts)
+    %w(username name admin allow_auto_login login_locked login_attempts)
   end
 end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,5 +1,5 @@
 module Admin::UsersHelper
   def user_attributes
-    %w(username name admin allow_auto_login login_locked login_attempts)
+    %w[username name admin allow_auto_login login_locked login_attempts]
   end
 end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -7,7 +7,7 @@ class AdminMailer < ApplicationMailer
     @url = url
     @remote_ip = remote_ip
     @user_agent = user_agent
-    subject = "[#{ENV.fetch('APP_NAME'){ 'APP_NAME' }.upcase}::#{Rails.env}] " \
+    subject = "[#{ENV.fetch('APP_NAME').upcase}::#{Rails.env}] " \
               "User Activity: #{activity} for @#{@username}"
     mail subject: subject
   end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,13 +1,14 @@
 class AdminMailer < ApplicationMailer
-  def activity_email(username, time, host, url, remote_ip, user_agent)
+  def activity_email(username, is_auto_login, time, host, url, remote_ip, user_agent)
     @username = username
+    activity = is_auto_login ? "Auto-Login" : "Login"
     @time = time
     @host = host
     @url = url
     @remote_ip = remote_ip
     @user_agent = user_agent
     subject = "[#{ENV.fetch('APP_NAME'){ 'APP_NAME' }.upcase}::#{Rails.env}] " \
-              "User Activity: Login for @#{username}"
+              "User Activity: #{activity} for @#{@username}"
     mail subject: subject
   end
 end

--- a/app/views/admin/users/user_form.html.haml
+++ b/app/views/admin/users/user_form.html.haml
@@ -30,7 +30,7 @@
       .col-md-6
         = f.text_field :name, 'Name', 'Max length 32.', nil, @user.errors[:name],
         opts.merge({maxlength: 32})
-      .col-md-6
+      .col-md-3
         .checkbox
           %label
             = f.check_box :login_locked, opts
@@ -38,6 +38,13 @@
           %p.help-block
             Currently user has #{@user.login_attempts} login attempts, and gets locked on 3rd attempt/fail.
             Unlocking sets attempts back to 0.
+      .col-md-3
+        .checkbox#allow-auto-login
+          %label
+            = f.check_box :allow_auto_login, opts
+            %strong Allow auto-login.
+          %p.help-block
+            Allows <strong>#{root_url}#{@user.username || 'username'}</strong> to automatically login user in. NOTE: This compromises security, and makes site vulnerable to a brute force 'rainbow' attack. However, it is a simple and pretty url that allows a user to access the site — use only in a time limited manner.
     .row
       .col-md-12
         .form-group.text-right

--- a/app/views/admin/users/user_form.html.haml
+++ b/app/views/admin/users/user_form.html.haml
@@ -44,7 +44,10 @@
             = f.check_box :allow_auto_login, opts
             %strong Allow auto-login.
           %p.help-block
-            Allows <strong>#{root_url}#{@user.username || 'username'}</strong> to automatically login user in. NOTE: This compromises security, and makes site vulnerable to a brute force 'rainbow' attack. However, it is a simple and pretty url that allows a user to access the site — use only in a time limited manner.
+            Allows <strong>#{root_url}#{@user.username || 'username'}</strong> to automatically login user in.
+            NOTE: This compromises security, and makes site vulnerable to a brute force 'rainbow' attack.
+            However, it is a simple and pretty url that allows a user to access the site —
+            use only in a time limited manner.
     .row
       .col-md-12
         .form-group.text-right

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,7 @@ Rails.application.routes.draw do
     resources :users
   end
 
+  get ':username', to: 'sessions#auto_login'
+
   Test::BackdoorController.load_routes if Rails.env.test?
 end

--- a/db/migrate/20170606203541_add_auto_login_to_users.rb
+++ b/db/migrate/20170606203541_add_auto_login_to_users.rb
@@ -1,0 +1,5 @@
+class AddAutoLoginToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :allow_auto_login, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170320172341) do
+ActiveRecord::Schema.define(version: 20170606203541) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.string   "username",        limit: 32
+    t.string   "username",         limit: 32
     t.string   "password_digest"
-    t.integer  "login_attempts",             default: 0
-    t.boolean  "login_locked",               default: false
-    t.boolean  "admin",                      default: false
-    t.string   "name",            limit: 32
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
+    t.integer  "login_attempts",              default: 0
+    t.boolean  "login_locked",                default: false
+    t.boolean  "admin",                       default: false
+    t.string   "name",             limit: 32
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
+    t.boolean  "allow_auto_login",            default: false
     t.index ["username"], name: "index_users_on_username", unique: true, using: :btree
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,6 @@
 # Character.create(name: 'Luke', movie: movies.first)
 
 User.create [
-                {username: 'admin', password: 'Secret1', name: 'Admin', admin: true},
-                {username: 'user', password: 'Secret1', name: 'User'}
+                {username: 'admin', password: 'Admin123', name: 'Admin', admin: true},
+                {username: 'user', password: 'User123', name: 'User'}
             ]

--- a/test/acceptance/page_obs/admin/users_page.rb
+++ b/test/acceptance/page_obs/admin/users_page.rb
@@ -1,7 +1,7 @@
 require "acceptance/page_obs/admin/admin_page"
 
 class Admin::UsersPage < Admin::AdminPage
-  ATTRIBUTES = %i(username name admin allow_auto_login login_locked login_attempts).freeze
+  ATTRIBUTES = %i[username name admin allow_auto_login login_locked login_attempts].freeze
 
   def has_user_table_header?
     # Verify number of TH vs. attributes
@@ -37,9 +37,9 @@ class Admin::UsersPage < Admin::AdminPage
 
       # Verify actions for each column
       actions_css = "#{css}:nth-of-type(#{ATTRIBUTES.size + 1}) a.btn"
-      %w(View Edit Delete).each_with_index do |action, aIdx|
-        unless page.has_css?("#{actions_css}:nth-of-type(#{aIdx + 1})", text: action)
-          raise "Expected to find action '#{action}' in button #{aIdx}, but did not."
+      %w(view edit delete).each_with_index do |action, aIdx|
+        unless page.has_css?("#{actions_css}:nth-of-type(#{aIdx + 1})", text: action.capitalize)
+          raise "Expected to find action '#{action.capitalize}' in button #{aIdx}, but did not."
         end
       end
     end

--- a/test/acceptance/page_obs/admin/users_page.rb
+++ b/test/acceptance/page_obs/admin/users_page.rb
@@ -1,7 +1,7 @@
 require "acceptance/page_obs/admin/admin_page"
 
 class Admin::UsersPage < Admin::AdminPage
-  ATTRIBUTES = [:username, :name, :admin, :allow_auto_login, :login_locked, :login_attempts].freeze
+  ATTRIBUTES = %i(username name admin allow_auto_login login_locked login_attempts).freeze
 
   def has_user_table_header?
     # Verify number of TH vs. attributes
@@ -37,9 +37,9 @@ class Admin::UsersPage < Admin::AdminPage
 
       # Verify actions for each column
       actions_css = "#{css}:nth-of-type(#{ATTRIBUTES.size + 1}) a.btn"
-      ['View', 'Edit', 'Delete'].each_with_index do |action, idx|
-        unless page.has_css?("#{actions_css}:nth-of-type(#{idx + 1})", text: action)
-          raise "Expected to find action '#{action}' in button #{idx}, but did not."
+      %w(View Edit Delete).each_with_index do |action, aIdx|
+        unless page.has_css?("#{actions_css}:nth-of-type(#{aIdx + 1})", text: action)
+          raise "Expected to find action '#{action}' in button #{aIdx}, but did not."
         end
       end
     end

--- a/test/acceptance/page_obs/admin/users_page.rb
+++ b/test/acceptance/page_obs/admin/users_page.rb
@@ -1,7 +1,7 @@
 require "acceptance/page_obs/admin/admin_page"
 
 class Admin::UsersPage < Admin::AdminPage
-  ATTRIBUTES = [:username, :name, :admin, :login_locked, :login_attempts].freeze
+  ATTRIBUTES = [:username, :name, :admin, :allow_auto_login, :login_locked, :login_attempts].freeze
 
   def has_user_table_header?
     # Verify number of TH vs. attributes
@@ -143,11 +143,11 @@ class Admin::UsersPage < Admin::AdminPage
   end
 
   def check(id)
-    page.check id: input_id(:login_locked)
+    page.check id: input_id(id)
   end
 
   def uncheck(id)
-    page.uncheck id: input_id(:login_locked)
+    page.uncheck id: input_id(id)
   end
 
   def has_demo_mode_flash?
@@ -156,6 +156,10 @@ class Admin::UsersPage < Admin::AdminPage
 
   def has_no_demo_mode_flash?
     page.has_no_css?('.alert-warning', text: Admin::UsersController::DEMO_MSG)
+  end
+
+  def has_help_block_content?(id, content)
+    page.find("##{id.to_s.dasherize} .help-block").has_content? content
   end
 
   private

--- a/test/acceptance/page_obs/sessions_page.rb
+++ b/test/acceptance/page_obs/sessions_page.rb
@@ -28,6 +28,10 @@ class SessionsPage < Page::Base
     page.has_css?('.alert', count: 1, text: 'You have been logged out.')
   end
 
+  def has_invalid_username_alert?
+    page.has_css?('.alert', count: 1, text: 'Invalid username.')
+  end
+
   def has_alert_count?(count)
     if count == 0
       page.has_no_css?('.alert')

--- a/test/acceptance/sessions_test.rb
+++ b/test/acceptance/sessions_test.rb
@@ -93,5 +93,16 @@ class SessionsTest < AcceptanceTest
     assert_current_path login_path
     assert @sessions_page.has_alert_count?(0)
     verify_login_page
+
+    # Acme client not allowed to login automatically
+    visit root_path + 'acme'
+    assert_current_path login_path
+    assert @sessions_page.has_invalid_username_alert?
+
+    # User with allow_auto_login
+    visit root_path + 'clientautologin'
+    assert_current_path root_path
+    assert @proxy_page.has_proxy_content?
+    assert @sessions_page.has_alert_count?(0)
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -30,3 +30,12 @@ client_locked:
   login_locked: true
   name: Locked
   created_at: <%= stamp %>
+
+client_auto_login:
+  username: clientautologin
+  password_digest: <%= BCrypt::Password.create('Secret1') %>
+  login_attempts: 0
+  login_locked: false
+  allow_auto_login: true
+  name: AutoLogin
+  created_at: <%= stamp %>

--- a/test/mailers/admin_mailer_test.rb
+++ b/test/mailers/admin_mailer_test.rb
@@ -6,7 +6,7 @@ def test_content(email, username, is_auto_login = false)
   # Test the body of the sent email contains what we expect it to
   assert_equal [ENV['ACTION_MAILER_DEFAULT_FROM']], email.from
   assert_equal [ENV['ACTION_MAILER_DEFAULT_TO']], email.to
-  subject = "[#{ENV.fetch('APP_NAME'){ 'APP_NAME' }.upcase}::#{Rails.env}] "\
+  subject = "[#{ENV.fetch('APP_NAME').upcase}::#{Rails.env}] "\
             "User Activity: #{activity} for @#{username}"
   assert_equal subject, email.subject
   assert_equal read_fixture('activity_email.html').join, email.html_part.body.to_s
@@ -20,7 +20,7 @@ class AdminMailerTest < ActionMailer::TestCase
     request = ActionDispatch::TestRequest.create({})
     username = 'client'
     args = username, false, now, request.host, request.url, request.remote_ip, request.user_agent
-    email = AdminMailer.activity_email *args
+    email = AdminMailer.activity_email(*args)
 
     # Test delivery now
     assert_emails 1 do
@@ -31,7 +31,7 @@ class AdminMailerTest < ActionMailer::TestCase
 
     # Test deliver_later
     ActiveJob::Base.queue_adapter = :test
-    email = AdminMailer.activity_email *args
+    email = AdminMailer.activity_email(*args)
     assert_enqueued_emails 1 do
       email.deliver_later
     end
@@ -45,7 +45,7 @@ class AdminMailerTest < ActionMailer::TestCase
     request = ActionDispatch::TestRequest.create({})
     username = 'client'
     args = username, true, now, request.host, request.url, request.remote_ip, request.user_agent
-    email = AdminMailer.activity_email *args
+    email = AdminMailer.activity_email(*args)
 
     # Test delivery now
     assert_emails 1 do

--- a/test/mailers/admin_mailer_test.rb
+++ b/test/mailers/admin_mailer_test.rb
@@ -1,25 +1,25 @@
 require 'test_helper'
 
+def test_content(email, username, is_auto_login = false)
+  activity = is_auto_login ? "Auto-Login" : "Login"
+
+  # Test the body of the sent email contains what we expect it to
+  assert_equal [ENV['ACTION_MAILER_DEFAULT_FROM']], email.from
+  assert_equal [ENV['ACTION_MAILER_DEFAULT_TO']], email.to
+  subject = "[#{ENV.fetch('APP_NAME'){ 'APP_NAME' }.upcase}::#{Rails.env}] "\
+            "User Activity: #{activity} for @#{username}"
+  assert_equal subject, email.subject
+  assert_equal read_fixture('activity_email.html').join, email.html_part.body.to_s
+  assert_equal read_fixture('activity_email.text').join, email.text_part.body.to_s
+end
+
 class AdminMailerTest < ActionMailer::TestCase
-
-  test "user activity" do
-
-    def test_content(email, username)
-      # Test the body of the sent email contains what we expect it to
-      assert_equal [ENV['ACTION_MAILER_DEFAULT_FROM']], email.from
-      assert_equal [ENV['ACTION_MAILER_DEFAULT_TO']], email.to
-      subject = "[#{ENV.fetch('APP_NAME'){ 'APP_NAME' }.upcase}::#{Rails.env}] "\
-                "User Activity: Login for @#{username}"
-      assert_equal subject, email.subject
-      assert_equal read_fixture('activity_email.html').join, email.html_part.body.to_s
-      assert_equal read_fixture('activity_email.text').join, email.text_part.body.to_s
-    end
-
+  test "user login with delivery tests" do
     # Create the email and store it for further assertions
     now = '2017-03-07 15:26:40 -0800' # Time.zone.now
     request = ActionDispatch::TestRequest.create({})
     username = 'client'
-    args = username, now, request.host, request.url, request.remote_ip, request.user_agent
+    args = username, false, now, request.host, request.url, request.remote_ip, request.user_agent
     email = AdminMailer.activity_email *args
 
     # Test delivery now
@@ -37,5 +37,21 @@ class AdminMailerTest < ActionMailer::TestCase
     end
     delivered_email = perform_enqueued_jobs { ActionMailer::DeliveryJob.perform_now(*enqueued_jobs.first[:args]) }
     test_content delivered_email, username
+  end
+
+  test 'user auto-login' do
+    # Create the email and store it for further assertions
+    now = '2017-03-07 15:26:40 -0800' # Time.zone.now
+    request = ActionDispatch::TestRequest.create({})
+    username = 'client'
+    args = username, true, now, request.host, request.url, request.remote_ip, request.user_agent
+    email = AdminMailer.activity_email *args
+
+    # Test delivery now
+    assert_emails 1 do
+      email.deliver_now
+    end
+    delivered_email = ActionMailer::Base.deliveries.last
+    test_content delivered_email, username, true
   end
 end


### PR DESCRIPTION
- add allow_auto_login boolean to user table
- when enabled, allows http://root_path/username to directly access content
- add usage warning to help block
- login notification emails will have 'Auto-Login' vs "Login' in subject line
- update seed passwords